### PR TITLE
feat: implement blog list in cmd

### DIFF
--- a/cmd/mizukinana/concerts/concerts.go
+++ b/cmd/mizukinana/concerts/concerts.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/mkfsn/mizukinana/cmd/mizukinana/utils/table"
 	"github.com/mkfsn/mizukinana/concerts"
 
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ func (o *Options) Run(cmd *cobra.Command) {
 	case "json":
 		result, err = json.MarshalIndent(concerts, "", "\t")
 	case "table":
-		result, err = concerts.MarshalTable()
+		result, err = table.Marshal(concerts)
 	default:
 		cmd.Printf("Error: %s\n", errUnsupportedOutputType.Error())
 		cmd.Usage()

--- a/cmd/mizukinana/nanaparty/blog/blog.go
+++ b/cmd/mizukinana/nanaparty/blog/blog.go
@@ -68,7 +68,7 @@ func NewCmdBlog() *cobra.Command {
 		},
 	}
 	cmd.Flags().DurationVar(&o.MaxTime, "max-time", utils.DefaultMaxTime, "Maximum time allowed for the request")
-	cmd.Flags().StringVarP(&o.Output, "output", "o", "", "One of 'yaml', 'json', 'csv' or 'table'")
+	cmd.Flags().StringVarP(&o.Output, "output", "o", "", "One of 'yaml', 'json' or 'table'")
 	cmd.Flags().IntVarP(&o.Latest, "", "n", -1, "Show only latest n blogs")
 	return cmd
 }

--- a/cmd/mizukinana/nanaparty/blog/blog.go
+++ b/cmd/mizukinana/nanaparty/blog/blog.go
@@ -10,9 +10,9 @@ import (
 	"github.com/mkfsn/mizukinana/cmd/mizukinana/utils"
 	"github.com/mkfsn/mizukinana/cmd/mizukinana/utils/table"
 	"github.com/mkfsn/mizukinana/nanaparty"
-	"gopkg.in/yaml.v2"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 type Options struct {

--- a/cmd/mizukinana/nanaparty/blog/blog.go
+++ b/cmd/mizukinana/nanaparty/blog/blog.go
@@ -2,25 +2,30 @@ package blog
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/mkfsn/mizukinana/cmd/mizukinana/utils"
+	"github.com/mkfsn/mizukinana/cmd/mizukinana/utils/table"
 	"github.com/mkfsn/mizukinana/nanaparty"
+	"gopkg.in/yaml.v2"
 
 	"github.com/spf13/cobra"
 )
 
 type Options struct {
 	MaxTime time.Duration
+	Latest  int
+	Output  string
 }
 
 func NewOptions() *Options {
 	return &Options{}
 }
 
-func (o *Options) Run() error {
+func (o *Options) Run() {
 	collection := nanaparty.New()
 
 	ctx, cancel := context.WithTimeout(context.Background(), o.MaxTime)
@@ -29,13 +34,29 @@ func (o *Options) Run() error {
 	blogs, err := collection.Blog(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return err
+		return
 	}
 
-	for _, blog := range blogs {
-		fmt.Printf("%v\n", blog.Info())
+	if o.Latest >= 0 {
+		blogs = blogs.Latest(o.Latest)
 	}
-	return nil
+
+	var res []byte
+	switch o.Output {
+	case "", "table":
+		res, err = table.Marshal(blogs)
+	case "json":
+		res, err = json.MarshalIndent(blogs, "", "    ")
+	case "yaml":
+		res, err = yaml.Marshal(blogs)
+	default:
+		err = fmt.Errorf("Invalid output: --output=%q is not acceptable\n", o.Output)
+	}
+	if err != nil {
+		fmt.Printf("error: %s\n", err)
+		return
+	}
+	fmt.Printf("%s\n", res)
 }
 
 func NewCmdBlog() *cobra.Command {
@@ -43,9 +64,11 @@ func NewCmdBlog() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "blog",
 		Run: func(cmd *cobra.Command, args []string) {
-			_ = o.Run()
+			o.Run()
 		},
 	}
 	cmd.Flags().DurationVar(&o.MaxTime, "max-time", utils.DefaultMaxTime, "Maximum time allowed for the request")
+	cmd.Flags().StringVarP(&o.Output, "output", "o", "", "One of 'yaml', 'json', 'csv' or 'table'")
+	cmd.Flags().IntVarP(&o.Latest, "", "n", -1, "Show only latest n blogs")
 	return cmd
 }

--- a/cmd/mizukinana/utils/table/marshaler.go
+++ b/cmd/mizukinana/utils/table/marshaler.go
@@ -1,0 +1,44 @@
+package table
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+var (
+	marshalerType = reflect.TypeOf((*Marshaler)(nil)).Elem()
+)
+
+type Marshaler interface {
+	MarshalTableHeader() []string
+	MarshalTableBody() [][]string
+}
+
+type MarshalerWithColWidth interface {
+	MarshalTableColWidth() int
+}
+
+func Marshal(v interface{}) ([]byte, error) {
+	value := reflect.ValueOf(v)
+	typ := value.Type()
+	if !typ.Implements(marshalerType) {
+		return nil, errors.New("unsupported type: " + typ.String())
+	}
+	m, ok := value.Interface().(Marshaler)
+	if !ok {
+		return []byte(""), nil
+	}
+
+	var buf bytes.Buffer
+	table := tablewriter.NewWriter(&buf)
+	if m, ok := value.Interface().(MarshalerWithColWidth); ok {
+		table.SetColWidth(m.MarshalTableColWidth())
+	}
+	table.SetHeader(m.MarshalTableHeader())
+	table.AppendBulk(m.MarshalTableBody())
+	table.Render()
+	return buf.Bytes(), nil
+}

--- a/concerts/concert.go
+++ b/concerts/concert.go
@@ -1,11 +1,8 @@
 package concerts
 
 import (
-	"bytes"
 	"strings"
 	"time"
-
-	"github.com/olekukonko/tablewriter"
 )
 
 const (
@@ -89,19 +86,11 @@ func (c Concerts) Filter(filter string) Concerts {
 	return result
 }
 
-func (c Concerts) MarshalTable() ([]byte, error) {
-	var buf bytes.Buffer
-
-	table := tablewriter.NewWriter(&buf)
-	table.SetColWidth(minTitleWidth)
-	table.SetHeader(c.header())
-	table.AppendBulk(c.body())
-	table.Render()
-
-	return buf.Bytes(), nil
+func (c Concerts) MarshalTableColWidth() int {
+	return minTitleWidth
 }
 
-func (c Concerts) header() []string {
+func (c Concerts) MarshalTableHeader() []string {
 	return []string{
 		"Date",
 		"Open",
@@ -113,7 +102,7 @@ func (c Concerts) header() []string {
 	}
 }
 
-func (c Concerts) body() [][]string {
+func (c Concerts) MarshalTableBody() [][]string {
 	rows := make([][]string, len(c))
 	for i, concert := range c {
 		rows[i] = []string{

--- a/nanaparty/blog.go
+++ b/nanaparty/blog.go
@@ -16,10 +16,33 @@ type NanaPartyBlog interface {
 	Detail(ctx context.Context) (*NanaPartyBlogDetail, error)
 }
 
+type NanaPartyBlogs []NanaPartyBlog
+
+func (n NanaPartyBlogs) Latest(i int) NanaPartyBlogs {
+	return n[:i]
+}
+
+func (n NanaPartyBlogs) MarshalTableHeader() []string {
+	return []string{"date", "title", "link"}
+}
+
+func (n NanaPartyBlogs) MarshalTableBody() [][]string {
+	var result [][]string
+	for _, blog := range n {
+		info := blog.Info()
+		result = append(result, []string{
+			info.Date,
+			info.Title,
+			info.Link,
+		})
+	}
+	return result
+}
+
 type NanaPartyBlogInfo struct {
-	Date  string
-	Title string
-	Link  string
+	Date  string `json:"date"  yaml:"date"`
+	Title string `json:"title" yaml:"title"`
+	Link  string `json:"link"  yaml:"link"`
 }
 
 type NanaPartyBlogDetail struct {
@@ -83,7 +106,7 @@ func (n nanaPartyBlog) Detail(ctx context.Context) (*NanaPartyBlogDetail, error)
 	return newNanaPartyBlogDetail(doc), nil
 }
 
-func makeNanaPartyBlog(doc *goquery.Document) []NanaPartyBlog {
+func makeNanaPartyBlog(doc *goquery.Document) NanaPartyBlogs {
 	var result []NanaPartyBlog
 	doc.Find("dl.backnumber_page dt").Each(func(i int, dt *goquery.Selection) {
 		dd := dt.Next()

--- a/nanaparty/nanaparty.go
+++ b/nanaparty/nanaparty.go
@@ -26,7 +26,7 @@ type NanaPartyCollection interface {
 	// Biography does the query to NanaPartyBiographyUrl and return a collection from the web page.
 	Biography(ctx context.Context) (NanaPartyBiographyCollection, error)
 	// Blog does the query to the NanaPartyBlogListUrl and return a list of Blog from the web page.
-	Blog(ctx context.Context) ([]NanaPartyBlog, error)
+	Blog(ctx context.Context) (NanaPartyBlogs, error)
 	// News does the query to NanaPartyNewsUrl and returns a list of news from the web page.
 	News(ctx context.Context) ([]*NanaPartyNews, error)
 	// Schedule does the query to NanaPartyScheduleUrl and returns a collection from the web page.
@@ -58,7 +58,7 @@ func (n *nanaParty) Biography(ctx context.Context) (NanaPartyBiographyCollection
 	return newNanaPartyBiography(doc), nil
 }
 
-func (n *nanaParty) Blog(ctx context.Context) ([]NanaPartyBlog, error) {
+func (n *nanaParty) Blog(ctx context.Context) (NanaPartyBlogs, error) {
 	doc, err := getDocumentFromUrl(ctx, NanaPartyBlogListUrl)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse document: %w", err)


### PR DESCRIPTION
Supported options:

- `-n`: Show latest n blog posts
- `-o`: Output format - one of 'yaml', 'json' or 'table'